### PR TITLE
constant-channel's receive-all should call receive- instead of receive

### DIFF
--- a/src/lamina/core/channel.clj
+++ b/src/lamina/core/channel.clj
@@ -133,7 +133,7 @@
 		(f %2)))
 	   true)
 	 (receive-all- [this fs]
-	   (receive this fs)
+	   (receive- this fs)
 	   true)
 	 (receive-while- [this callback-predicate-map]
 	   (doseq [[f pred] callback-predicate-map]

--- a/test/lamina/test/channel.clj
+++ b/test/lamina/test/channel.clj
@@ -90,7 +90,16 @@
       `(receive-all ch f)
       (map
 	(fn [x] `(enqueue-fn ~x))
-	(range 3)))))
+	(range 3))))
+  (testing "constant-channel"
+    (let [c (constant-channel)]
+      (receive-all c #(is (= 0 %)))
+      (enqueue c 0)
+      )
+    )
+  )
+
+
 
 (deftest test-receive
   (doall


### PR DESCRIPTION
Hi Zach,

I came across a small problem with constant-channel's receive-all.  Here is a fix and test case.

Regards,

Paudi
