### PR TITLE
Making Channel counted

### DIFF
--- a/src/lamina/core/channel.clj
+++ b/src/lamina/core/channel.clj
@@ -26,7 +26,9 @@
   ChannelProtocol
   (consumer [_] consumer)
   (queue [_] queue)
-  (toString [_] (str queue)))
+  (toString [_] (str queue))
+  clojure.lang.Counted
+  (count [q] (count queue)))
 
 (defn channel [& messages]
   (let [source (o/observable)]


### PR DESCRIPTION
Hey Zach, 

We had a need to check whether a Channel is empty or not.  I extended clojure.lang.Counted to Channel (using the existing EventQueue implementation).  I'm not sure whether that was missing because you didn't want that to be part of the Channel abstraction (which I would understand).  I'd be equally happy with an equals? implementation OR a peek if those match better.

What do you think?

Alex
