### PR TITLE
channel.cancel-callback should cancel on-closed callbacks

### DIFF
--- a/src/lamina/core/channel.clj
+++ b/src/lamina/core/channel.clj
@@ -91,6 +91,7 @@
   "Cancels one or more callbacks."
   [ch & callbacks]
   (-> ch queue (q/cancel-callbacks callbacks))
+  (-> ch consumer (o/unsubscribe callbacks))
   (-> ch queue q/distributor (o/unsubscribe callbacks)))
 
 (defn enqueue


### PR DESCRIPTION
This patch modifies cancel-callback to also cancels callbacks added to the consumer Observable.
