### PR TITLE
add mapcat*

### DIFF
--- a/src/lamina/core.clj
+++ b/src/lamina/core.clj
@@ -77,6 +77,7 @@
     ch))
 
 (import-fn #'seq/fork)
+(import-fn #'seq/mapcat*)
 (import-fn #'seq/map*)
 (import-fn #'seq/filter*)
 (import-fn #'seq/remove*)

--- a/test/lamina/test/channel.clj
+++ b/test/lamina/test/channel.clj
@@ -332,6 +332,23 @@
       (is (drained? ch*))
       (is (drained? ch)))))
 
+(deftest test-mapcat*
+  (let [s [1 2 3]
+	f range]
+
+    (let [ch (apply closed-channel s)
+	  ch* (mapcat* f ch)]
+      (is (= (mapcat f s) (channel-seq ch*)))
+      (is (drained? ch))
+      (is (drained? ch*)))
+
+    (let [ch (channel)
+	  ch* (mapcat* f ch)]
+      (async-enqueue ch s true)
+      (is (= (mapcat f s) (channel-seq ch* 2500)))
+      (is (drained? ch))
+      (is (drained? ch*)))))
+
 (deftest test-map*
   (let [s (range 10)
 	f #(* % 2)]


### PR DESCRIPTION
I needed `mapcat*` and also realized that the duplication in `map*` and `filter*` could be removed by implementing them using `mapcat*`.

So, here's it is.
