### PR TITLE
Stacktrace logging compatibility with tools.logging

### DIFF
--- a/src/lamina/core/observable.clj
+++ b/src/lamina/core/observable.clj
@@ -42,19 +42,19 @@
 	   (when message-callback
 	     (message-callback msgs))
 	   (catch Exception e
-	     (log/error "Error in message callback" e))))
+	     (log/error e "Error in message callback"))))
        (on-close [_]
 	 (try
 	   (when close-callback
 	     (close-callback))
 	   (catch Exception e
-	     (log/error "Error in close callback" e))))
+	     (log/error e "Error in close callback"))))
        (on-observers-changed [_ observers]
 	 (try
 	   (when observers-callback
 	     (observers-callback observers))
 	   (catch Exception e
-	     (log/error "Error in observers-changed callback" e)))))))
+	     (log/error e "Error in observers-changed callback")))))))
 
 ;;;
 


### PR DESCRIPTION
This patch ensures that stacktraces are printed properly in 1.3 per this thread in the group:

https://groups.google.com/d/topic/aleph-lib/yvE5F9g_moU/discussion
