### PR TITLE
Implement tagged client + tests.

### DIFF
--- a/src/lamina/connections.clj
+++ b/src/lamina/connections.clj
@@ -300,9 +300,8 @@
 (defn tagged-client
   "Like pipelined-client, but for protocols in which responses may come in any
 order, associating requests with responses via an opaque tag.  The request-tag
-function should accept a request and return a (potentially updated) request and
-associated tag value.  The response-tag function should accept a response and
-return a (potentially unwrapped) response value and the extracted tag."
+function should accept a request and return the associated tag.  The
+response-tag function should accept a response and return the extracted tag."
   ([request-tag response-tag connection-generator]
      (tagged-client request-tag response-tag connection-generator nil))
   ([request-tag response-tag connection-generator options]
@@ -318,7 +317,7 @@ return a (potentially unwrapped) response value and the extracted tag."
            pause? (atom false)
            results (ref {})
            response-handler (fn [response]
-                              (let [[response tag] (response-tag response),
+                              (let [tag (response-tag response),
                                     result (get @results tag)]
                                 (dosync (commute results dissoc tag))
                                 (when (result-channel? result)
@@ -360,7 +359,7 @@ return a (potentially unwrapped) response value and the extracted tag."
                    (if (= ::close ch)
                      (error! result (Exception. "Client has been deactivated."))
                      (when-not (has-completed? result)
-                       (let [[request tag] (request-tag request)]
+                       (let [tag (request-tag request)]
                          (dosync (commute results assoc tag result))
                          (on-error result
                            (fn [_] (dosync (commute results dissoc tag))))

--- a/test/lamina/test/connections.clj
+++ b/test/lamina/test/connections.clj
@@ -119,7 +119,7 @@
      (simple-response client-fn -1)))
 
 (defn constant-tagged-client [& args]
-  (let [tag-zero (fn [x] [x 0])]
+  (let [tag-zero (constantly 0)]
     (apply tagged-client tag-zero tag-zero args)))
 
 (deftest test-simple-response
@@ -148,8 +148,7 @@
      (reordered-response client-fn -1)))
 
 (defn identity-tagged-client [& args]
-  (let [tag-identity (fn [x] [x x])]
-    (apply tagged-client tag-identity tag-identity args)))
+  (apply tagged-client identity identity args))
 
 (deftest test-reordered-response
   (reordered-response identity-tagged-client))


### PR DESCRIPTION
Implements a tagged-client analogous to the existing pipelined-client.  In a tagged-client each request/response is marked by an opaque tag.  Responses with different tags may return in arbitrary order.  This should allow straightforward implementation of multiplex protocols like BEEP and 9P.
