### PR TITLE
Fix regression with channels not supporting clojure.lang.Counted

### DIFF
--- a/src/lamina/core/channel.clj
+++ b/src/lamina/core/channel.clj
@@ -55,6 +55,9 @@
         (set! emitter n)
         n)
       emitter))
+  clojure.lang.Counted
+  (count [_]
+    (-> (g/queue emitter) q/messages count))
   Object
   (toString [_]
     (if-not (= ::none (g/error-value receiver ::none))
@@ -216,7 +219,7 @@
          (when-let [q (g/queue emitter)]
            (-> n g/queue (q/append (q/messages q)))))
       nil)
-    (Channel. n n))) 
+    (Channel. n n)))
 
 (defn close
   "Closes the channel. Returns if successful, false if the channel is already closed or in an
@@ -224,7 +227,7 @@
   [channel]
   (g/close (receiver-node channel)))
 
-(defn error [channel err]  
+(defn error [channel err]
   (g/error (receiver-node channel) err))
 
 (defn closed?


### PR DESCRIPTION
Hello Zach, 

Channels do not support c.l.Counted on perf:

;; on perf:
user> (use 'lamina.core)
nil
user> (count (channel 1 2 3 ))
; Evaluation aborted. 

;; on master:
user> (use 'lamina.core)
nil
user> (count (channel 1 2 3 ))
3

I wasn't entirely sure if this belongs to the Channel type or at a lower level.  

edit: Apparently the same is true for metadata support

Max
