### PR TITLE
fix related to options arity change

### DIFF
--- a/src/lamina/connections.clj
+++ b/src/lamina/connections.clj
@@ -116,7 +116,7 @@
           :or {timeout 5000
                interval 10000}
            :as heartbeat} (:heartbeat options)]
-      
+
       (when-not (contains? heartbeat :request)
         (throw (IllegalArgumentException. "heartbeat must specify :request")))
 
@@ -142,7 +142,7 @@
 (defn try-instrument [options f]
   (if (contains? options :name)
     (with-meta
-      (apply instrument f (apply concat options))
+      (instrument f options)
       (meta f))
     f))
 

--- a/src/lamina/trace/instrument.clj
+++ b/src/lamina/trace/instrument.clj
@@ -37,10 +37,10 @@
          ~(when timeout `(when ~timeout (~timeout ~args)))))))
 
 (defn instrument-task
-  [f & {:keys [executor timeout implicit? with-bindings?]
-        :as options
-        :or {implicit? true
-             with-bindings? false}}]
+  [f {:keys [executor timeout implicit? with-bindings?]
+      :as options
+      :or {implicit? true
+           with-bindings? false}}]
   (let [nm (name (:name options))
         enter-probe (probe-channel [nm :enter])
         return-probe (probe-channel [nm :return])
@@ -48,7 +48,7 @@
     (fn
       ([]
          (instrument-task-body nm executor enter-probe return-probe implicit? with-bindings? timeout
-           (f) [])) 
+           (f) []))
       ([a]
          (instrument-task-body nm executor enter-probe return-probe implicit? with-bindings? timeout
            (f a) [a]))
@@ -61,7 +61,7 @@
       ([a b c d]
          (instrument-task-body nm executor enter-probe return-probe implicit? with-bindings? timeout
            (f a b c d) [a b c d]))
-      ([a b c d e] 
+      ([a b c d e]
          (instrument-task-body nm executor enter-probe return-probe implicit? with-bindings? timeout
            (f a b c d e) [a b c d e]))
       ([a b c d e & rest]
@@ -161,7 +161,7 @@
   In this case, :timeout will also interrupt the thread if it is still actively
   computing the value, and the 'return' probe will include an :enqueued-duration
   parameter that describes the time, in nanoseconds, spent waiting to be executed."
-  
+
   [f {:keys [executor timeout probes implicit? with-bindings?]
       :as options
       :or {implicit? true
@@ -169,7 +169,7 @@
   (when-not (contains? options :name)
     (throw (IllegalArgumentException. "Instrumented functions must have a :name defined.")))
   (if executor
-    (apply instrument-task f (apply concat options))
+    (instrument-task f options)
     (let [nm (name (:name options))
           enter-probe (probe-channel [nm :enter])
           return-probe (probe-channel [nm :return])
@@ -192,7 +192,7 @@
         ([a b c d]
            (instrument-body nm enter-probe return-probe implicit?
              (f a b c d) [a b c d]))
-         ([a b c d e] 
+         ([a b c d e]
            (instrument-body nm enter-probe return-probe implicit?
              (f a b c d e) [a b c d e]))
         ([a b c d e & rest]


### PR DESCRIPTION
related to https://github.com/mpenet/lamina/commit/d6e5c0c98cb5c0d823d60b6216ea4683557f26e9 

It seems it wasn't complete, I had arity exceptions showing up caused by it (through aleph.redis):

for instance: 

```
Exception in thread "main" clojure.lang.ArityException: Wrong number of args (11) passed to: instrument$instrument
    at clojure.lang.AFn.throwArity(AFn.java:437)
    at clojure.lang.AFn.invoke(AFn.java:84)
    at clojure.lang.AFn.applyToHelper(AFn.java:235)
    at clojure.lang.AFn.applyTo(AFn.java:151)
    at clojure.core$apply.invoke(core.clj:603)
    at lamina.connections$try_instrument.invoke(connections.clj:145)
    at lamina.connections$pipelined_client.invoke(connections.clj:290)
    at aleph.redis$redis_client.invoke(redis.clj:75)
    at qualia.store.redis$eval14626$fn__14627.invoke(redis.clj:70)
    at clojure.lang.MultiFn.invoke(MultiFn.java:163)
    at qualia.test.core$eval14723.invoke(core.clj:55)
    at clojure.lang.Compiler.eval(Compiler.java:6511)
    at clojure.lang.Compiler.eval(Compiler.java:6501)
    at clojure.lang.Compiler.load(Compiler.java:6952)
    at clojure.lang.RT.loadResourceScript(RT.java:359)
    at clojure.lang.RT.loadResourceScript(RT.java:350)
    at clojure.lang.RT.load(RT.java:429)
    at clojure.lang.RT.load(RT.java:400)
    at clojure.core$load$fn__4890.invoke(core.clj:5415)
    at clojure.core$load.doInvoke(core.clj:5414)
    at clojure.lang.RestFn.invoke(RestFn.java:408)
    at clojure.core$load_one.invoke(core.clj:5227)
    at clojure.core$load_lib.doInvoke(core.clj:5264)
    at clojure.lang.RestFn.applyTo(RestFn.java:142)
    at clojure.core$apply.invoke(core.clj:603)
    at clojure.core$load_libs.doInvoke(core.clj:5298)
    at clojure.lang.RestFn.applyTo(RestFn.java:137)
    at clojure.core$apply.invoke(core.clj:603)
    at clojure.core$require.doInvoke(core.clj:5381)
    at clojure.lang.RestFn.invoke(RestFn.java:421)
    at user$eval29.invoke(NO_SOURCE_FILE:1)
    at clojure.lang.Compiler.eval(Compiler.java:6511)
    at clojure.lang.Compiler.eval(Compiler.java:6501)
    at clojure.lang.Compiler.eval(Compiler.java:6477)
    at clojure.core$eval.invoke(core.clj:2797)
    at clojure.main$eval_opt.invoke(main.clj:297)
    at clojure.main$initialize.invoke(main.clj:316)
    at clojure.main$null_opt.invoke(main.clj:349)
    at clojure.main$main.doInvoke(main.clj:427)
    at clojure.lang.RestFn.invoke(RestFn.java:421)
    at clojure.lang.Var.invoke(Var.java:419)
    at clojure.lang.AFn.applyToHelper(AFn.java:163)
    at clojure.lang.Var.applyTo(Var.java:532)
    at clojure.main.main(main.java:37)
```

I am not 100% confident this is what you intended here (whole maps vs unrolled maps) but it fixes my issue for now. 

Max
