### PR TITLE
Fix distributor doc and example

### DIFF
--- a/src/lamina/core/channel.clj
+++ b/src/lamina/core/channel.clj
@@ -370,7 +370,7 @@
    (distributor :type
      (fn [facet ch]
        (siphon
-         (->> ch (map* :value) average)
+         (->> ch (map* :value) mean)
          (sink #(println \"average for\" facet \"is\" %)))))"
   [facet channel-initializer]
   (let [receiver (g/node identity)


### PR DESCRIPTION
Fix distributor doc so that the example channel-initializer mirrors (channel-initializer facet ch) and average is now mean.
