### PR TITLE
Fix Split Macro

### DIFF
--- a/src/lamina/core.clj
+++ b/src/lamina/core.clj
@@ -206,8 +206,8 @@
        (sink->> (filter* odd?) log-odd)))"
   [& downstream-channels]
   `(let [ch# (channel)]
-     (doseq [x# ~downstream-channels]
-       (siphon ch## x#))
+     (doseq [x# (list ~@downstream-channels)]
+       (siphon ch# x#))
      ch#))
 
 (defmacro siphon->>


### PR DESCRIPTION
Removed an extra # from ch## and added (list ~@downstream-channels) to keep the macro from trying to create code that calls the channels being passed in.
