### PR TITLE
Removing repetitive/redundant error logging from pipelines

### DIFF
--- a/src/lamina/core/pipeline.clj
+++ b/src/lamina/core/pipeline.clj
@@ -296,8 +296,6 @@
         ~(if error-handler
            (complex-error-handler error-handler (meta &form))
            `(error [_# result# _# ex#]
-              (when-not ~(contains? options :error-handler)
-                (log/error ex# (str "Unhandled exception in pipeline at " ~location)))
               (if result#
                 (r/error result# ex#)
                 (r/error-result ex#))))


### PR DESCRIPTION
Pipelines are supposed to be chainable, but if the result channel going through a chain of pipelines has been realized as an error, every single pipeline that does not have an :error-handler will log the exception and stacktrace.

This can potentially be annoying in a server where an error occurs early on in a pipeline chain, but a single error handler is attached at the last pipeline.

I'm not sure how pipelines work internally, but I would imagine that a lot of the code that would have deref'ed the failed result channel and triggered the exception (hence the required logging) would get short-circuited, not trigger anything and fail silently. I'm not sure of a way around that, but it seems like a bad idea to have pipelines without any error handling code.
