### PR TITLE
Make channel->lazy-seq truly lazy

### DIFF
--- a/src/lamina/core/operators.clj
+++ b/src/lamina/core/operators.clj
@@ -309,12 +309,13 @@
 
 (defn channel->lazy-seq-
   [read-fn cleanup-fn]
-  (let [msg @(read-fn)]
-    (if (= ::end msg)
-      (do
-        (cleanup-fn)
-        nil)
-      (cons msg (lazy-seq (channel->lazy-seq- read-fn cleanup-fn))))))
+  (lazy-seq 
+    (let [msg @(read-fn)]
+      (if (= ::end msg)
+        (do
+          (cleanup-fn)
+          nil)
+        (cons msg (channel->lazy-seq- read-fn cleanup-fn))))))
 
 (defn channel->lazy-seq
   "Returns a sequence.  As elements of the sequence are realized, messages from the


### PR DESCRIPTION
Moved the lazy-seq call to enclose the hole body of channel->lazy-seq- so it does not block until first message arrives in channel. Previously, this call was blocking:

(lazy-seq->channel (channel->lazy-seq (channel)))

Now it return instantly.
