### PR TITLE
allow query operators without leading dot

### DIFF
--- a/src/lamina/query/parse.clj
+++ b/src/lamina/query/parse.clj
@@ -295,8 +295,13 @@
 
 (def operators
   (token
-    (chain transform-prefix (many operator))
-    (fn [[_ operators]]
+    (route
+      transform-prefix (many operator)
+      #"" (token
+            (chain operator (many operator))
+            (fn [[operator operators]]
+              (cons operator operators))))
+    (fn [operators]
       (vec (collapse-group-bys operators)))))
 
 (def stream

--- a/test/lamina/test/query.clj
+++ b/test/lamina/test/query.clj
@@ -155,3 +155,17 @@
           (parse-string-query query))
        ".foo('xyz')"
        ".foo(\"xyz\")"))
+
+(deftest test-operator-without-leading-dot
+  (is (= '[(group-by [:foo] [:bar :baz (rate)])]
+         (parse-string-query ".group-by(foo).bar.baz.rate()")))
+  (is (= '[(group-by [:foo :bar (to-upper)] [])]
+         (parse-string-query ".group-by(foo.bar.to-upper())"))))
+
+(deftest test-single-dot-in-where
+  (is (= '[(where ("=" [] 4))]
+         (parse-string-query ".where(. = 4)"))))
+
+(deftest invalid-queries
+  (is (thrown? Throwable
+               (parse-string-query ".x...y"))))


### PR DESCRIPTION
Would this work to allow operators without a leading `.` in `group-by`?

@amalloy looked over the commit, and all the test pass, but it is very possible that I'm missing something obvious.
