### PR TITLE
check that the timer is not nil before calling a function on it

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.vgeshel/lamina "0.5.0"
+(defproject lamina "0.5.0"
   :description "event-driven data structures for clojure"
   :min-lein-version "2.0.0"
   :dependencies [[org.clojure/tools.logging "0.2.4"]


### PR DESCRIPTION
This check is being done in a couple of other places, but not here. I don't have a concise test case for this, but it did blow up on me in a real use scenario.
