### PR TITLE
Fix atom sink typo causing ClassCastException

### DIFF
--- a/src/lamina/core/watch.clj
+++ b/src/lamina/core/watch.clj
@@ -25,7 +25,7 @@
   "Transforms a `channel` into an atom which updated with the value of each new message."
   ([channel]
      (atom-sink nil channel))
-  ([initial-value ch]
+  ([initial-value channel]
      (let [a (atom initial-value)]
        (receive-all channel #(reset! a %))
        a)))

--- a/test/lamina/test/watch.clj
+++ b/test/lamina/test/watch.clj
@@ -1,0 +1,20 @@
+;;   Copyright (c) Aaron VonderHaar. All rights reserved.
+;;   The use and distribution terms for this software are covered by the
+;;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;   which can be found in the file epl-v10.html at the root of this distribution.
+;;   By using this software in any fashion, you are agreeing to be bound by
+;;   the terms of this license.
+;;   You must not remove this notice, or any other, from this software.
+
+(ns lamina.test.watch
+  (:use
+    [clojure test]
+    [lamina.core channel]
+    [lamina.core.watch]))
+
+;;;
+
+(deftest test-atom-sink
+  (let [ch (channel 0 1 2)
+        !a (atom-sink ch)]
+    (is (= @!a 2))))


### PR DESCRIPTION
`atom-sink` has a typo which causes a `ClassCastException` for any use of it, for example:

``` clojure
(use 'lamina.core)
(atom-sink (channel 1 2 3))
  => ClassCastException lamina.core.channel$channel cannot be cast to lamina.core.channel.IChannel  lamina.core.channel/receive-all (channel.clj:253)
```
