### PR TITLE
Fix use of fn names for instrumented tasks

### DIFF
--- a/src/lamina/executor.clj
+++ b/src/lamina/executor.clj
@@ -26,10 +26,10 @@
    value or error."
   [& body]
   (let [explicit-name? (string? (first body))
-        name (if explicit-name? (first body) "task")
+        name (symbol (if explicit-name? (first body) "task"))
         body (if explicit-name? (rest body) body)]
     `((trace/instrumented-fn
-        task
+        ~name
         {:executor default-executor}
         []
         ~@body))))
@@ -39,7 +39,7 @@
    value or error.  Unlike `task`, thread-local bindings are preserved when evaluating the body."
   [& body]
   (let [explicit-name? (string? (first body))
-        name (if explicit-name? (first body) "bound-task")
+        name (symbol (if explicit-name? (first body) "bound-task"))
         body (if explicit-name? (rest body) body)]
     `((trace/instrumented-fn
         ~name


### PR DESCRIPTION
This looks like what was intended for the `task` macro, right? It looks like you were intentionally emitting `(fn fn-name ...)` in `instrumented-fn`, but `task` and `bound-task` pass the wrong thing in that spot.
