### PR TITLE
Fix dev profile ordering

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -12,8 +12,8 @@
                                   [codox-md "0.2.0" :exclusions [org.clojure/clojure]]]}
              :1.3 {:dependencies [[org.clojure/clojure "1.3.0"]]}
              :1.4 {:dependencies [[org.clojure/clojure "1.4.0"]]}
-             :1.6 {:dependencies [[org.clojure/clojure "1.6.0-master-SNAPSHOT"]]}}
-  :aliases {"all" ["with-profile" "1.6,dev:1.3,dev:dev:1.4,dev"]}
+             :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}}
+  :aliases {"all" ["with-profile" "dev:dev,1.6:dev,1.3:dev,1.4"]}
   :plugins [[codox "0.6.2"]]
   :codox {:writer codox-md.writer/write-docs
           :include [lamina.core


### PR DESCRIPTION
Profiles are merged from left to right, so the dev profile needs to be before the version profile. This breaks the Travis tests as they weren't previously running under all versions of Clojure.
